### PR TITLE
Add interactive stats, processes tab, and auto-download GeoIP DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,21 +71,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -121,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +156,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -154,7 +165,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -187,22 +198,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "confy"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b1f4c00870f07dc34adcac82bb6a72cc5aabca8536ba1797e01df51d2ce9a0"
-dependencies = [
- "directories",
- "serde",
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -256,36 +264,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core 0.10.2",
- "darling_macro 0.10.2",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -297,19 +281,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core 0.10.2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -318,93 +291,30 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
+name = "dirs"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling 0.10.2",
- "derive_builder_core",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling 0.10.2",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dns-lookup"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
-dependencies = [
- "cfg-if",
- "libc",
- "socket2 0.4.10",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -412,24 +322,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570d109b813e904becc80d8d5da38376818a143348413f7149f1340fe04754d4"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "equivalent"
@@ -448,113 +340,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
 
 [[package]]
 name = "getrandom"
@@ -579,18 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,24 +391,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -625,177 +406,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-system-resolver"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea26c5d0b6ab9d72219f65000af310f042a740926f7b2fa3553e774036e2e7"
-dependencies = [
- "derive_builder",
- "dns-lookup",
- "hyper",
- "tokio",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
-]
 
 [[package]]
 name = "indoc"
@@ -812,18 +426,12 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ipnetwork"
@@ -856,12 +464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,12 +483,6 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -909,37 +505,26 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
 name = "maperick"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "cassowary",
  "clap",
- "confy",
  "crossterm",
+ "dirs",
+ "flate2",
  "maxminddb",
  "netstat2",
- "public-ip",
  "rand",
  "ratatui",
- "serde",
  "sysinfo",
- "termcolor",
  "termion",
- "unicode-segmentation",
- "unicode-width 0.1.14",
+ "ureq",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "maxminddb"
@@ -958,6 +543,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -982,16 +577,7 @@ dependencies = [
  "libc",
  "num-derive",
  "num-traits",
- "thiserror",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1002,12 +588,6 @@ checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -1089,47 +669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,43 +687,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "public-ip"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4c40db5262d93298c363a299f8bc1b3a956a78eecddba3bc0e58b76e2f419a"
-dependencies = [
- "dns-lookup",
- "futures-core",
- "futures-util",
- "http",
- "hyper",
- "hyper-system-resolver",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "trust-dns-client",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
 ]
 
 [[package]]
@@ -1269,13 +777,27 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1289,6 +811,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1340,13 +897,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -1380,10 +934,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.12"
+name = "simd-adler32"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1392,52 +946,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -1460,12 +972,18 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1490,17 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "sysinfo"
 version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,15 +1019,6 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1539,7 +1037,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1554,125 +1061,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "libc",
- "mio",
- "pin-project-lite",
- "socket2 0.6.3",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1680,97 +1072,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "futures",
- "futures-task",
- "pin-project",
- "tracing",
-]
-
-[[package]]
-name = "trust-dns-client"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4ef9b9bde0559b78a4abb00339143750085f05e5a453efb7b8bef1061f09dc"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "log",
- "radix_trie",
- "rand",
- "thiserror",
- "time",
- "tokio",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "log",
- "rand",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1802,22 +1107,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
-name = "url"
-version = "2.5.8"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "form_urlencoded",
- "idna 1.1.0",
+ "base64",
+ "flate2",
+ "log",
  "percent-encoding",
- "serde",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
 ]
 
 [[package]]
-name = "utf8_iter"
-version = "1.0.4"
+name = "ureq-proto"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -1826,19 +1154,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -1857,15 +1185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1890,7 +1209,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1927,16 +1246,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1945,7 +1255,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1954,7 +1264,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1968,40 +1278,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2011,21 +1300,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2041,21 +1318,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2065,65 +1330,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -2146,55 +1361,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.7"
+name = "zeroize"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "maperick"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+description = "Visualize active TCP connections on a TUI world map"
+license = "MIT"
+repository = "https://github.com/schlunsen/maperick"
+keywords = ["tui", "network", "geoip", "terminal", "tcp"]
+categories = ["command-line-utilities", "network-programming", "visualization"]
+readme = "README.md"
 
 [features]
 default = ["crossterm"]
@@ -9,21 +15,15 @@ default = ["crossterm"]
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 netstat2 = "0.9"
-bitflags = "2"
-cassowary = "0.3"
-unicode-segmentation = "1.12"
-unicode-width = "0.1"
 termion = { version = "4", optional = true }
 crossterm = { version = "0.28", optional = true }
-serde = { version = "1", features = ["derive"] }
 ratatui = "0.29"
-rand = "0.8"
 sysinfo = "0.33"
-termcolor = "1"
 maxminddb = "0.24"
-public-ip = "0.2"
-confy = "0.6"
 anyhow = "1"
+dirs = "6"
+ureq = "3"
+flate2 = "1"
 
 [dev-dependencies]
 rand = "0.8"

--- a/justfile
+++ b/justfile
@@ -8,9 +8,39 @@ default:
 build:
     cargo build --release
 
-# Run maperick with enhanced graphics
-run path="mmdbs/GeoLite2-City.mmdb":
+# Install maperick to ~/.cargo/bin (adds to PATH) and download GeoIP DB
+install:
+    cargo install --path .
+    @echo ""
+    @echo "Downloading GeoIP database (if not already present)..."
+    @maperick --db-path > /dev/null 2>&1 || true
+    @maperick --db-path 2>/dev/null && echo "GeoIP DB location: $(maperick --db-path 2>/dev/null)" || true
+    @echo ""
+    @echo "maperick installed! Run 'maperick -e' to start."
+
+# Run maperick with enhanced graphics (auto-downloads DB if needed)
+run:
+    cargo run -- -e
+
+# Run maperick with a specific database path
+run-with-db path:
     cargo run -- -e -p {{path}}
+
+# Show where the GeoIP database is stored
+db-path:
+    cargo run -- --db-path
+
+# Run tests
+test:
+    cargo test
+
+# Run clippy lints
+lint:
+    cargo clippy -- -D warnings
+
+# Format code
+fmt:
+    cargo fmt
 
 # Serve GitHub Pages locally (requires Python 3)
 pages:

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,6 +65,8 @@ pub struct ProcessInfo {
     pub ips: Vec<String>,
     pub total_connections: u128,
     pub ports: HashSet<u16>,
+    pub coords: Vec<(f64, f64)>,
+    pub locations: Vec<String>,
 }
 
 pub struct App<'a> {
@@ -335,10 +337,21 @@ impl<'a> App<'a> {
                     ips: vec![],
                     total_connections: 0,
                     ports: HashSet::new(),
+                    coords: vec![],
+                    locations: vec![],
                 });
                 entry.ips.push(server.name.clone());
                 entry.total_connections += server.count;
                 entry.ports.extend(&server.ports);
+                entry.coords.push(server.coords);
+                let loc = if server.country.is_empty() {
+                    server.location.clone()
+                } else {
+                    format!("{}, {}", server.location, server.country)
+                };
+                if !entry.locations.contains(&loc) {
+                    entry.locations.push(loc);
+                }
             }
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::Instant;
 
 use maperick::netstats::{self, get_sockets};
 use netstat2::*;
-use serde::{Deserialize, Serialize};
+use ratatui::widgets::TableState;
 use sysinfo::System;
 
 use maxminddb::{geoip2, Reader};
+
+const SPARKLINE_WINDOW: usize = 60;
 
 pub struct TabsState<'a> {
     pub titles: Vec<&'a str>,
@@ -21,7 +24,7 @@ impl<'a> TabsState<'a> {
     }
 
     pub fn help(&mut self) {
-        self.index = 2;
+        self.index = self.titles.len() - 1;
     }
 
     pub fn previous(&mut self) {
@@ -36,33 +39,47 @@ impl<'a> TabsState<'a> {
 pub struct Server {
     pub name: String,
     pub location: String,
+    pub country: String,
     pub coords: (f64, f64),
-    pub status: String,
     pub count: u128,
+    pub ports: Vec<u16>,
+    pub processes: Vec<String>,
+}
+
+/// Per-IP session history, accumulated across ticks
+pub struct ServerHistory {
+    pub first_seen: Instant,
+    pub last_seen: Instant,
+    pub times_detected: u64,
+    pub total_connections: u128,
+    pub all_ports: HashSet<u16>,
+    pub all_processes: HashSet<String>,
+    pub recent_counts: VecDeque<u64>,
+    pub location: String,
+    pub country: String,
+}
+
+/// Per-process aggregated view
+pub struct ProcessInfo {
+    pub name: String,
+    pub ips: Vec<String>,
+    pub total_connections: u128,
+    pub ports: HashSet<u16>,
 }
 
 pub struct App<'a> {
     pub title: &'a str,
     pub should_quit: bool,
     pub tabs: TabsState<'a>,
-    #[allow(dead_code)]
-    pub progress: f64,
     pub reader: Reader<Vec<u8>>,
     pub servers: Vec<Server>,
     pub enhanced_graphics: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct MaperickConfig {
-    path: String,
-}
-
-impl Default for MaperickConfig {
-    fn default() -> Self {
-        Self {
-            path: "mmdbs/GeoLite2-City.mmdb".into(),
-        }
-    }
+    pub table_state: TableState,
+    pub server_history: HashMap<String, ServerHistory>,
+    pub show_detail_popup: bool,
+    // Processes tab
+    pub process_list: Vec<ProcessInfo>,
+    pub process_table_state: TableState,
 }
 
 impl<'a> App<'a> {
@@ -71,31 +88,27 @@ impl<'a> App<'a> {
         enhanced_graphics: bool,
         geodb_path: String,
     ) -> anyhow::Result<App<'a>> {
-        let mut cfg: MaperickConfig =
-            confy::load("maperick", None).unwrap_or_else(|_| MaperickConfig::default());
+        let reader = maxminddb::Reader::open_readfile(&geodb_path).map_err(|e| {
+            anyhow::anyhow!("Failed to open GeoIP database at '{}': {}", geodb_path, e)
+        })?;
 
-        let reader = if geodb_path.is_empty() {
-            maxminddb::Reader::open_readfile(&cfg.path).map_err(|e| {
-                anyhow::anyhow!("Failed to open GeoIP database at '{}': {}", cfg.path, e)
-            })?
-        } else {
-            cfg.path = geodb_path.clone();
-            if let Err(e) = confy::store("maperick", None, &cfg) {
-                eprintln!("Warning: couldn't store config: {}", e);
-            }
-            maxminddb::Reader::open_readfile(&geodb_path).map_err(|e| {
-                anyhow::anyhow!("Failed to open GeoIP database at '{}': {}", geodb_path, e)
-            })?
-        };
+        let mut table_state = TableState::default();
+        table_state.select(Some(0));
+        let mut process_table_state = TableState::default();
+        process_table_state.select(Some(0));
 
         Ok(App {
             title,
             should_quit: false,
-            tabs: TabsState::new(vec!["Tab0", "Tab1", "Help"]),
-            progress: 0.0,
+            tabs: TabsState::new(vec!["Map", "Servers", "Processes", "Help"]),
             reader,
             servers: vec![],
             enhanced_graphics,
+            table_state,
+            server_history: HashMap::new(),
+            show_detail_popup: false,
+            process_list: vec![],
+            process_table_state,
         })
     }
 
@@ -103,16 +116,55 @@ impl<'a> App<'a> {
         self.tabs.next();
     }
 
-    #[allow(dead_code)]
-    pub fn on_help(&mut self) {
-        self.tabs.help();
-    }
-
     pub fn on_left(&mut self) {
         self.tabs.previous();
     }
 
+    pub fn on_up(&mut self) {
+        match self.tabs.index {
+            1 => navigate_up(&mut self.table_state, self.servers.len()),
+            2 => navigate_up(&mut self.process_table_state, self.process_list.len()),
+            _ => {}
+        }
+    }
+
+    pub fn on_down(&mut self) {
+        match self.tabs.index {
+            1 => navigate_down(&mut self.table_state, self.servers.len()),
+            2 => navigate_down(&mut self.process_table_state, self.process_list.len()),
+            _ => {}
+        }
+    }
+
+    pub fn on_enter(&mut self) {
+        if self.tabs.index == 1 && self.selected_server().is_some() {
+            self.show_detail_popup = true;
+        }
+    }
+
+    pub fn on_escape(&mut self) {
+        if self.show_detail_popup {
+            self.show_detail_popup = false;
+        } else {
+            self.should_quit = true;
+        }
+    }
+
+    pub fn selected_server(&self) -> Option<&Server> {
+        self.table_state
+            .selected()
+            .and_then(|i| self.servers.get(i))
+    }
+
+    pub fn selected_server_history(&self) -> Option<&ServerHistory> {
+        self.selected_server()
+            .and_then(|s| self.server_history.get(&s.name))
+    }
+
     pub fn on_key(&mut self, c: char) {
+        if self.show_detail_popup {
+            return; // swallow keys while popup is open
+        }
         match c {
             'q' => {
                 self.should_quit = true;
@@ -131,8 +183,11 @@ impl<'a> App<'a> {
         );
         let sockets: Vec<netstats::SocketInfo> = get_sockets(&sys, AddressFamilyFlags::IPV4);
 
+        // Group connections by remote IP, collecting counts, ports, and process names
         let mut remote_addrs: Vec<std::net::IpAddr> = vec![];
-        let mut remote_addrs_map: HashMap<String, u128> = HashMap::new();
+        let mut counts: HashMap<String, u128> = HashMap::new();
+        let mut ports: HashMap<String, HashSet<u16>> = HashMap::new();
+        let mut procs: HashMap<String, HashSet<String>> = HashMap::new();
 
         for s in sockets {
             if s.protocol != ProtocolFlags::TCP {
@@ -151,14 +206,29 @@ impl<'a> App<'a> {
             };
 
             let key = remote_addr.to_string();
-            let count = remote_addrs_map.entry(key).or_insert(0);
+            let count = counts.entry(key.clone()).or_insert(0);
             if *count == 0 {
                 remote_addrs.push(remote_addr);
             }
             *count += 1;
+
+            if let Some(port) = s.remote_port {
+                ports.entry(key.clone()).or_default().insert(port);
+            }
+
+            for p in &s.processes {
+                if !p.name.is_empty() {
+                    procs.entry(key.clone()).or_default().insert(p.name.clone());
+                }
+            }
         }
 
+        // Remember the selected index before clearing
+        let prev_selected = self.table_state.selected();
         self.servers.clear();
+
+        // Track which IPs are active this tick (for sparkline zero-fill)
+        let mut active_ips: HashSet<String> = HashSet::new();
 
         for addr in &remote_addrs {
             let city: geoip2::City = match self.reader.lookup(*addr) {
@@ -171,6 +241,11 @@ impl<'a> App<'a> {
                 None => "",
             };
 
+            let country = match city.country.and_then(|c| c.names) {
+                Some(names) => names.get("en").copied().unwrap_or(""),
+                None => "",
+            };
+
             let location = match &city.location {
                 Some(loc) => match (loc.latitude, loc.longitude) {
                     (Some(lat), Some(lon)) => (lat, lon),
@@ -179,20 +254,133 @@ impl<'a> App<'a> {
                 None => continue,
             };
 
-            let connection_count = remote_addrs_map
-                .get(&addr.to_string())
-                .copied()
-                .unwrap_or(1);
+            let key = addr.to_string();
+            let connection_count = counts.get(&key).copied().unwrap_or(1);
+
+            let mut port_list: Vec<u16> = ports
+                .get(&key)
+                .map(|s| s.iter().copied().collect())
+                .unwrap_or_default();
+            port_list.sort();
+
+            let mut proc_list: Vec<String> = procs
+                .get(&key)
+                .map(|s| s.iter().cloned().collect())
+                .unwrap_or_default();
+            proc_list.sort();
+
+            // Update session history
+            active_ips.insert(key.clone());
+            let hist = self.server_history.entry(key).or_insert_with(|| ServerHistory {
+                first_seen: Instant::now(),
+                last_seen: Instant::now(),
+                times_detected: 0,
+                total_connections: 0,
+                all_ports: HashSet::new(),
+                all_processes: HashSet::new(),
+                recent_counts: VecDeque::with_capacity(SPARKLINE_WINDOW),
+                location: String::new(),
+                country: String::new(),
+            });
+            hist.last_seen = Instant::now();
+            hist.times_detected += 1;
+            hist.total_connections += connection_count;
+            hist.all_ports.extend(&port_list);
+            hist.all_processes.extend(proc_list.iter().cloned());
+            hist.location = String::from(cityname);
+            hist.country = String::from(country);
+            if hist.recent_counts.len() >= SPARKLINE_WINDOW {
+                hist.recent_counts.pop_front();
+            }
+            hist.recent_counts.push_back(connection_count as u64);
 
             self.servers.push(Server {
                 name: addr.to_string(),
                 location: String::from(cityname),
+                country: String::from(country),
                 coords: location,
-                status: String::from("Connected"),
                 count: connection_count,
+                ports: port_list,
+                processes: proc_list,
             });
         }
+
+        // Zero-fill sparkline for IPs not seen this tick
+        for (ip, hist) in &mut self.server_history {
+            if !active_ips.contains(ip) {
+                if hist.recent_counts.len() >= SPARKLINE_WINDOW {
+                    hist.recent_counts.pop_front();
+                }
+                hist.recent_counts.push_back(0);
+            }
+        }
+
+        // Restore selection, clamping to new bounds
+        if !self.servers.is_empty() {
+            let idx = prev_selected.unwrap_or(0).min(self.servers.len() - 1);
+            self.table_state.select(Some(idx));
+        }
+
+        // Build process list
+        self.rebuild_process_list();
     }
+
+    fn rebuild_process_list(&mut self) {
+        let mut proc_map: HashMap<String, ProcessInfo> = HashMap::new();
+
+        for server in &self.servers {
+            for proc_name in &server.processes {
+                let entry = proc_map.entry(proc_name.clone()).or_insert_with(|| ProcessInfo {
+                    name: proc_name.clone(),
+                    ips: vec![],
+                    total_connections: 0,
+                    ports: HashSet::new(),
+                });
+                entry.ips.push(server.name.clone());
+                entry.total_connections += server.count;
+                entry.ports.extend(&server.ports);
+            }
+        }
+
+        let prev_selected = self.process_table_state.selected();
+        self.process_list = proc_map.into_values().collect();
+        self.process_list.sort_by(|a, b| b.total_connections.cmp(&a.total_connections));
+
+        if !self.process_list.is_empty() {
+            let idx = prev_selected.unwrap_or(0).min(self.process_list.len() - 1);
+            self.process_table_state.select(Some(idx));
+        }
+    }
+}
+
+fn navigate_up(state: &mut TableState, len: usize) {
+    let i = match state.selected() {
+        Some(i) => {
+            if i == 0 {
+                len.saturating_sub(1)
+            } else {
+                i - 1
+            }
+        }
+        None => 0,
+    };
+    state.select(Some(i));
+}
+
+fn navigate_down(state: &mut TableState, len: usize) {
+    let i = match state.selected() {
+        Some(i) => {
+            if len == 0 {
+                0
+            } else if i >= len - 1 {
+                0
+            } else {
+                i + 1
+            }
+        }
+        None => 0,
+    };
+    state.select(Some(i));
 }
 
 #[cfg(test)]
@@ -237,8 +425,6 @@ mod tests {
 
     #[test]
     fn test_on_key_quit() {
-        // We can't easily construct App without a DB file,
-        // but we can test TabsState independently
         let mut tabs = TabsState::new(vec!["A", "B"]);
         tabs.next();
         assert_eq!(tabs.index, 1);
@@ -251,8 +437,24 @@ mod tests {
         let mut tabs = TabsState::new(vec!["Only"]);
         assert_eq!(tabs.index, 0);
         tabs.next();
-        assert_eq!(tabs.index, 0); // wraps to 0
+        assert_eq!(tabs.index, 0);
         tabs.previous();
-        assert_eq!(tabs.index, 0); // wraps to 0
+        assert_eq!(tabs.index, 0);
+    }
+
+    #[test]
+    fn test_navigate_up_wraps() {
+        let mut state = TableState::default();
+        state.select(Some(0));
+        navigate_up(&mut state, 5);
+        assert_eq!(state.selected(), Some(4));
+    }
+
+    #[test]
+    fn test_navigate_down_wraps() {
+        let mut state = TableState::default();
+        state.select(Some(4));
+        navigate_down(&mut state, 5);
+        assert_eq!(state.selected(), Some(0));
     }
 }

--- a/src/crossterm.rs
+++ b/src/crossterm.rs
@@ -10,7 +10,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub fn run(tick_rate: Duration, enhanced_graphics: bool, geodb_path: String) -> anyhow::Result<()> {
+pub fn run(
+    tick_rate: Duration,
+    enhanced_graphics: bool,
+    geodb_path: String,
+) -> anyhow::Result<()> {
     // setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -19,7 +23,7 @@ pub fn run(tick_rate: Duration, enhanced_graphics: bool, geodb_path: String) -> 
     let mut terminal = Terminal::new(backend)?;
 
     // create app and run it
-    let app = App::new("Crossterm Demo", enhanced_graphics, geodb_path)?;
+    let app = App::new("Maperick", enhanced_graphics, geodb_path)?;
     let res = run_app(&mut terminal, app, tick_rate);
 
     // restore terminal
@@ -52,12 +56,23 @@ fn run_app(
             .unwrap_or_else(|| Duration::from_secs(0));
         if crossterm::event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
-                match key.code {
-                    KeyCode::Char(c) => app.on_key(c),
-                    KeyCode::Esc => app.on_key('q'),
-                    KeyCode::Right => app.on_right(),
-                    KeyCode::Left => app.on_left(),
-                    _ => {}
+                if app.show_detail_popup {
+                    // Modal: only Esc/q close the popup
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Char('q') => app.on_escape(),
+                        _ => {}
+                    }
+                } else {
+                    match key.code {
+                        KeyCode::Char(c) => app.on_key(c),
+                        KeyCode::Esc => app.on_escape(),
+                        KeyCode::Right => app.on_right(),
+                        KeyCode::Left => app.on_left(),
+                        KeyCode::Up => app.on_up(),
+                        KeyCode::Down => app.on_down(),
+                        KeyCode::Enter => app.on_enter(),
+                        _ => {}
+                    }
                 }
             }
         }

--- a/src/geodb.rs
+++ b/src/geodb.rs
@@ -1,0 +1,177 @@
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+const DB_FILENAME: &str = "dbip-city-lite.mmdb";
+
+/// Returns the platform-specific data directory for maperick.
+/// e.g. ~/.local/share/maperick on Linux, ~/Library/Application Support/maperick on macOS
+pub fn data_dir() -> Result<PathBuf> {
+    let base = dirs::data_dir().context("Could not determine system data directory")?;
+    Ok(base.join("maperick"))
+}
+
+/// Returns the expected path to the GeoIP database file.
+pub fn default_db_path() -> Result<PathBuf> {
+    Ok(data_dir()?.join(DB_FILENAME))
+}
+
+/// Ensures the GeoIP database exists, downloading it if necessary.
+/// If `explicit_path` is provided and non-empty, uses that instead.
+/// Returns the resolved path to the database file.
+pub fn ensure_db(explicit_path: Option<&str>) -> Result<PathBuf> {
+    // If user gave an explicit path, just use it (and verify it exists)
+    if let Some(path) = explicit_path {
+        if !path.is_empty() {
+            let p = PathBuf::from(path);
+            if p.exists() {
+                return Ok(p);
+            }
+            anyhow::bail!(
+                "GeoIP database not found at '{}'. Remove the -p flag to auto-download.",
+                path
+            );
+        }
+    }
+
+    // Check the standard data directory
+    let db_path = default_db_path()?;
+    if db_path.exists() {
+        return Ok(db_path);
+    }
+
+    // Database not found — download it
+    download_db(&db_path)?;
+    Ok(db_path)
+}
+
+/// Downloads the DB-IP City Lite database (gzipped) and extracts it.
+fn download_db(dest: &PathBuf) -> Result<()> {
+    // Build the URL for the current month's database
+    let now = chrono_free_date();
+    let url = format!(
+        "https://download.db-ip.com/free/dbip-city-lite-{}-{:02}.mmdb.gz",
+        now.0, now.1
+    );
+
+    eprintln!("GeoIP database not found. Downloading...");
+    eprintln!("  Source: {}", url);
+
+    // Ensure the data directory exists
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory '{}'", parent.display()))?;
+    }
+
+    // Download
+    let response = ureq::get(&url)
+        .call()
+        .with_context(|| format!("Failed to download GeoIP database from {}", url))?;
+
+    let mut body = Vec::new();
+    response
+        .into_body()
+        .as_reader()
+        .read_to_end(&mut body)
+        .context("Failed to read download response")?;
+
+    // Decompress gzip
+    let mut decoder = GzDecoder::new(&body[..]);
+    let mut mmdb_data = Vec::new();
+    decoder
+        .read_to_end(&mut mmdb_data)
+        .context("Failed to decompress GeoIP database")?;
+
+    // Write to file
+    let mut file = fs::File::create(dest)
+        .with_context(|| format!("Failed to create file '{}'", dest.display()))?;
+    file.write_all(&mmdb_data)
+        .with_context(|| format!("Failed to write GeoIP database to '{}'", dest.display()))?;
+
+    let size_mb = mmdb_data.len() as f64 / (1024.0 * 1024.0);
+    eprintln!(
+        "  Downloaded {:.1} MB to {}",
+        size_mb,
+        dest.display()
+    );
+    eprintln!("  Database provided by DB-IP (https://db-ip.com), CC-BY-4.0 license.");
+    eprintln!();
+
+    Ok(())
+}
+
+/// Returns (year, month) without pulling in the chrono crate.
+/// Uses std::time::SystemTime.
+fn chrono_free_date() -> (i32, u32) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Simple calculation: days since epoch
+    let days = (secs / 86400) as i64;
+    // Approximate year and month from days since 1970-01-01
+    // This is a simplified calculation, good enough for building a URL
+    let mut y = 1970i32;
+    let mut remaining = days;
+    loop {
+        let days_in_year = if is_leap(y) { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let months_days: [i64; 12] = if is_leap(y) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut m = 1u32;
+    for &d in &months_days {
+        if remaining < d {
+            break;
+        }
+        remaining -= d;
+        m += 1;
+    }
+    (y, m)
+}
+
+fn is_leap(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_data_dir_is_valid() {
+        let dir = data_dir();
+        assert!(dir.is_ok());
+        let dir = dir.unwrap();
+        assert!(dir.to_string_lossy().contains("maperick"));
+    }
+
+    #[test]
+    fn test_default_db_path_contains_filename() {
+        let path = default_db_path().unwrap();
+        assert!(path.to_string_lossy().contains(DB_FILENAME));
+    }
+
+    #[test]
+    fn test_chrono_free_date_is_reasonable() {
+        let (year, month) = chrono_free_date();
+        assert!(year >= 2024);
+        assert!((1..=12).contains(&month));
+    }
+
+    #[test]
+    fn test_explicit_nonexistent_path_fails() {
+        let result = ensure_db(Some("/nonexistent/path/to/db.mmdb"));
+        assert!(result.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 mod app;
 #[cfg(feature = "crossterm")]
 mod crossterm;
+mod geodb;
 #[cfg(feature = "termion")]
 mod termion;
 mod ui;
@@ -16,7 +17,7 @@ use std::time::Duration;
 /// Map tcp connections on a TUI world map
 #[derive(Parser, Debug)]
 #[clap(name = "maperick")]
-#[clap(version = "0.1")]
+#[clap(version = "0.2")]
 #[clap(about, long_about = None)]
 pub struct Args {
     /// time in ms between two ticks.
@@ -24,21 +25,35 @@ pub struct Args {
     #[clap(short = 't', default_missing_value = "250")]
     tick_rate: Option<u64>,
 
-    #[clap(help = "Path to geolite2 db")]
-    #[clap(short = 'p', default_missing_value = "mmdbs/GeoLite2-City.mmdb")]
+    /// Path to GeoIP mmdb file. If omitted, auto-downloads to data dir.
+    #[clap(short = 'p', long = "path")]
     path: Option<String>,
 
     /// whether unicode symbols are used to improve the overall look of the app
     #[clap(short = 'e', default_missing_value = "true")]
     enhanced_graphics: bool,
+
+    /// Print the path where the GeoIP database is stored
+    #[clap(long = "db-path", help = "Print the GeoIP database path and exit")]
+    db_path: bool,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let tick_rate = Duration::from_millis(args.tick_rate.unwrap_or(250));
-    let geodb_path = args.path.unwrap_or_default();
+    // --db-path: just print the location and exit
+    if args.db_path {
+        let path = geodb::default_db_path()?;
+        println!("{}", path.display());
+        return Ok(());
+    }
 
-    run(tick_rate, args.enhanced_graphics, geodb_path)?;
+    // Resolve the GeoIP database, downloading if needed
+    let geodb_path = geodb::ensure_db(args.path.as_deref())?;
+    let geodb_path_str = geodb_path.to_string_lossy().to_string();
+
+    let tick_rate = Duration::from_millis(args.tick_rate.unwrap_or(250));
+
+    run(tick_rate, args.enhanced_graphics, geodb_path_str)?;
     Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -195,10 +195,17 @@ fn draw_servers_tab(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_processes_tab(f: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .constraints([Constraint::Min(10), Constraint::Length(10)].as_ref())
-        .direction(Direction::Vertical)
+    // Split: left side (table + detail), right side (map)
+    let h_chunks = Layout::default()
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)].as_ref())
+        .direction(Direction::Horizontal)
         .split(area);
+
+    // Left side: table on top, detail below
+    let left_chunks = Layout::default()
+        .constraints([Constraint::Min(8), Constraint::Length(8)].as_ref())
+        .direction(Direction::Vertical)
+        .split(h_chunks[0]);
 
     let normal_style = Style::default().fg(Color::Green);
     let selected_style = Style::default()
@@ -207,35 +214,23 @@ fn draw_processes_tab(f: &mut Frame, app: &mut App, area: Rect) {
         .add_modifier(Modifier::BOLD);
 
     let rows = app.process_list.iter().map(|p| {
-        let ports_str: String = {
-            let mut sorted: Vec<u16> = p.ports.iter().copied().collect();
-            sorted.sort();
-            sorted
-                .iter()
-                .take(5)
-                .map(|port| format_port(*port))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
         Row::new(vec![
             p.name.clone(),
             p.ips.len().to_string(),
             p.total_connections.to_string(),
-            ports_str,
         ])
         .style(normal_style)
     });
 
     let widths = [
-        Constraint::Length(25),
-        Constraint::Length(10),
-        Constraint::Length(14),
-        Constraint::Min(20),
+        Constraint::Length(22),
+        Constraint::Length(6),
+        Constraint::Length(8),
     ];
 
     let table = Table::new(rows, widths)
         .header(
-            Row::new(vec!["Process", "Unique IPs", "Connections", "Ports"])
+            Row::new(vec!["Process", "IPs", "Conns"])
                 .style(
                     Style::default()
                         .fg(Color::Yellow)
@@ -245,61 +240,55 @@ fn draw_processes_tab(f: &mut Frame, app: &mut App, area: Rect) {
         )
         .block(
             Block::default()
-                .title("Processes (↑↓ to select)")
+                .title("Processes (↑↓)")
                 .borders(Borders::ALL),
         )
         .row_highlight_style(selected_style)
         .highlight_symbol("► ");
 
-    f.render_stateful_widget(table, chunks[0], &mut app.process_table_state);
+    f.render_stateful_widget(table, left_chunks[0], &mut app.process_table_state);
 
-    // Process detail pane
-    let detail_text = if let Some(selected) = app.process_table_state.selected() {
-        if let Some(proc) = app.process_list.get(selected) {
-            let ips_str = if proc.ips.len() <= 5 {
-                proc.ips.join(", ")
-            } else {
-                format!(
-                    "{} ... and {} more",
-                    proc.ips[..5].join(", "),
-                    proc.ips.len() - 5
-                )
-            };
-            vec![
-                Line::from(vec![
-                    Span::styled("  Process: ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(
-                        &proc.name,
-                        Style::default()
-                            .fg(Color::LightMagenta)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                ]),
-                Line::from(vec![
-                    Span::styled("  Unique IPs: ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(
-                        proc.ips.len().to_string(),
-                        Style::default().fg(Color::White),
-                    ),
-                ]),
-                Line::from(vec![
-                    Span::styled(
-                        "  Total connections: ",
-                        Style::default().fg(Color::DarkGray),
-                    ),
-                    Span::styled(
-                        proc.total_connections.to_string(),
-                        Style::default().fg(Color::LightGreen),
-                    ),
-                ]),
-                Line::from(vec![
-                    Span::styled("  Connected to: ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(ips_str, Style::default().fg(Color::LightCyan)),
-                ]),
-            ]
-        } else {
-            vec![Line::from("")]
-        }
+    // Detail pane (bottom-left)
+    let selected_proc = app
+        .process_table_state
+        .selected()
+        .and_then(|i| app.process_list.get(i));
+
+    let detail_text = if let Some(proc) = selected_proc {
+        let ports_str: String = {
+            let mut sorted: Vec<u16> = proc.ports.iter().copied().collect();
+            sorted.sort();
+            sorted
+                .iter()
+                .take(6)
+                .map(|port| format_port(*port))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let locations_str = proc.locations.join(", ");
+        vec![
+            Line::from(vec![
+                Span::styled(" ", Style::default()),
+                Span::styled(
+                    &proc.name,
+                    Style::default()
+                        .fg(Color::LightMagenta)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {} IPs, {} conns", proc.ips.len(), proc.total_connections),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(" Ports: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(ports_str, Style::default().fg(Color::LightCyan)),
+            ]),
+            Line::from(vec![
+                Span::styled(" Locations: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(locations_str, Style::default().fg(Color::White)),
+            ]),
+        ]
     } else {
         vec![Line::from(Span::styled(
             "  No process selected",
@@ -308,14 +297,56 @@ fn draw_processes_tab(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     let detail = Paragraph::new(detail_text)
+        .block(Block::default().title("Details").borders(Borders::ALL))
+        .style(Style::default().fg(Color::White))
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(detail, left_chunks[1]);
+
+    // Right side: mini map filtered to selected process's connections
+    let proc_coords: Vec<(f64, f64)> = selected_proc
+        .map(|p| p.coords.clone())
+        .unwrap_or_default();
+
+    let proc_name_title = selected_proc
+        .map(|p| format!("Map: {}", p.name))
+        .unwrap_or_else(|| "Map".to_string());
+
+    let map = Canvas::default()
         .block(
             Block::default()
-                .title("Process Details")
+                .title(proc_name_title)
                 .borders(Borders::ALL),
         )
-        .style(Style::default().fg(Color::White));
+        .paint(move |ctx| {
+            ctx.draw(&Map {
+                color: Color::DarkGray,
+                resolution: MapResolution::High,
+            });
+            ctx.layer();
 
-    f.render_widget(detail, chunks[1]);
+            for &(lat, lon) in &proc_coords {
+                ctx.print(
+                    lon,
+                    lat,
+                    Span::styled(
+                        "●",
+                        Style::default()
+                            .fg(Color::LightMagenta)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                );
+            }
+        })
+        .marker(if app.enhanced_graphics {
+            symbols::Marker::Braille
+        } else {
+            symbols::Marker::Block
+        })
+        .x_bounds([-180.0, 180.0])
+        .y_bounds([-90.0, 90.0]);
+
+    f.render_widget(map, h_chunks[1]);
 }
 
 fn draw_help_tab(f: &mut Frame, _app: &mut App, area: Rect) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,17 +1,17 @@
 use crate::app::App;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
     symbols,
     text::{Line, Span},
-    widgets::canvas::{Canvas, Line as CanvasLine, Map, MapResolution},
-    widgets::{Block, Borders, Paragraph, Row, Table, Tabs, Wrap},
+    widgets::canvas::{Canvas, Map, MapResolution},
+    widgets::{Block, Borders, Clear, Paragraph, Row, Sparkline, Table, Tabs, Wrap},
     Frame,
 };
 
 pub fn draw(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
-        .constraints([Constraint::Length(0), Constraint::Min(0)].as_ref())
+        .constraints([Constraint::Length(3), Constraint::Min(0)].as_ref())
         .split(f.area());
     let titles = app
         .tabs
@@ -25,19 +25,20 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         .select(app.tabs.index);
     f.render_widget(tabs, chunks[0]);
     match app.tabs.index {
-        0 => draw_first_tab(f, app, chunks[1]),
-        1 => draw_second_tab(f, app, chunks[1]),
-        2 => draw_help_tab(f, app, chunks[1]),
+        0 => draw_map_tab(f, app, chunks[1]),
+        1 => draw_servers_tab(f, app, chunks[1]),
+        2 => draw_processes_tab(f, app, chunks[1]),
+        3 => draw_help_tab(f, app, chunks[1]),
         _ => {}
     };
+
+    // Render popup overlay on top of everything
+    if app.show_detail_popup {
+        draw_detail_popup(f, app);
+    }
 }
 
-fn draw_first_tab(f: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .constraints([Constraint::Percentage(100)].as_ref())
-        .direction(Direction::Horizontal)
-        .split(area);
-
+fn draw_map_tab(f: &mut Frame, app: &mut App, area: Rect) {
     let map = Canvas::default()
         .block(
             Block::default()
@@ -51,27 +52,16 @@ fn draw_first_tab(f: &mut Frame, app: &mut App, area: Rect) {
             });
             ctx.layer();
 
-            for (i, s1) in app.servers.iter().enumerate() {
-                for s2 in &app.servers[i + 1..] {
-                    ctx.draw(&CanvasLine {
-                        x1: s1.coords.1,
-                        y1: s1.coords.0,
-                        y2: s2.coords.0,
-                        x2: s2.coords.1,
-                        color: Color::LightBlue,
-                    });
-                }
-            }
             for server in &app.servers {
-                let color = if server.status == "Up" {
-                    Color::Green
-                } else {
-                    Color::Red
+                let color = match server.count {
+                    1 => Color::Green,
+                    2..=5 => Color::Yellow,
+                    _ => Color::Red,
                 };
                 ctx.print(
                     server.coords.1,
                     server.coords.0,
-                    Span::styled("X", Style::default().fg(color)),
+                    Span::styled("●", Style::default().fg(color)),
                 );
             }
         })
@@ -82,71 +72,553 @@ fn draw_first_tab(f: &mut Frame, app: &mut App, area: Rect) {
         })
         .x_bounds([-180.0, 180.0])
         .y_bounds([-90.0, 90.0]);
-    f.render_widget(map, chunks[0]);
+    f.render_widget(map, area);
 }
 
-fn draw_help_tab(f: &mut Frame, _app: &mut App, area: Rect) {
+fn draw_servers_tab(f: &mut Frame, app: &mut App, area: Rect) {
     let chunks = Layout::default()
-        .constraints([Constraint::Percentage(100)].as_ref())
-        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(10), Constraint::Length(10)].as_ref())
+        .direction(Direction::Vertical)
         .split(area);
 
-    let text = vec![
-        Line::from(vec![Span::styled(
-            "Help: ?",
-            Style::default().fg(Color::LightGreen),
-        )]),
-        Line::from(Span::styled(
-            "Move tabs: <>",
-            Style::default().fg(Color::LightGreen),
-        )),
-        Line::from(Span::styled(
-            "Quit: q",
-            Style::default().fg(Color::LightGreen),
-        )),
-    ];
-
-    let p = Paragraph::new(text)
-        .block(Block::default().title("Help Menu").borders(Borders::ALL))
-        .style(Style::default().fg(Color::White).bg(Color::Black))
-        .alignment(Alignment::Left)
-        .wrap(Wrap { trim: true });
-
-    f.render_widget(p, chunks[0]);
-}
-
-fn draw_second_tab(f: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .constraints([Constraint::Percentage(100)].as_ref())
-        .direction(Direction::Horizontal)
-        .split(area);
-
-    let up_style = Style::default().fg(Color::Green);
+    let normal_style = Style::default().fg(Color::Green);
+    let selected_style = Style::default()
+        .fg(Color::Black)
+        .bg(Color::LightGreen)
+        .add_modifier(Modifier::BOLD);
 
     let rows = app.servers.iter().map(|s| {
+        let proc_str = if s.processes.is_empty() {
+            String::from("-")
+        } else {
+            s.processes.join(", ")
+        };
         Row::new(vec![
             String::from(&s.name),
             String::from(&s.location),
-            s.status.to_string(),
+            proc_str,
             s.count.to_string(),
         ])
-        .style(up_style)
+        .style(normal_style)
     });
 
     let widths = [
-        Constraint::Length(25),
-        Constraint::Length(25),
         Constraint::Length(20),
+        Constraint::Length(28),
         Constraint::Length(20),
+        Constraint::Length(8),
     ];
 
     let table = Table::new(rows, widths)
         .header(
-            Row::new(vec!["Server", "Location", "Status", "Count"])
-                .style(Style::default().fg(Color::Yellow))
+            Row::new(vec!["Server", "Location", "Process", "Count"])
+                .style(
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )
                 .bottom_margin(1),
         )
-        .block(Block::default().title("Servers").borders(Borders::ALL));
+        .block(
+            Block::default()
+                .title("Servers (↑↓ select, Enter details)")
+                .borders(Borders::ALL),
+        )
+        .row_highlight_style(selected_style)
+        .highlight_symbol("► ");
 
-    f.render_widget(table, chunks[0]);
+    f.render_stateful_widget(table, chunks[0], &mut app.table_state);
+
+    // Detail pane
+    let detail_text = if let Some(server) = app.selected_server() {
+        let ports_str = if server.ports.is_empty() {
+            String::from("-")
+        } else {
+            server
+                .ports
+                .iter()
+                .map(|p| format_port(*p))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let procs_str = if server.processes.is_empty() {
+            String::from("-")
+        } else {
+            server.processes.join(", ")
+        };
+
+        vec![
+            Line::from(vec![
+                Span::styled("  IP: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    &server.name,
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("  Location: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{}, {}", server.location, server.country),
+                    Style::default().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("  Connections: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    server.count.to_string(),
+                    Style::default().fg(Color::LightGreen),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("  Ports: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(ports_str, Style::default().fg(Color::LightCyan)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Processes: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(procs_str, Style::default().fg(Color::LightMagenta)),
+            ]),
+        ]
+    } else {
+        vec![Line::from(Span::styled(
+            "  No server selected",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    };
+
+    let detail = Paragraph::new(detail_text)
+        .block(Block::default().title("Details").borders(Borders::ALL))
+        .style(Style::default().fg(Color::White));
+
+    f.render_widget(detail, chunks[1]);
+}
+
+fn draw_processes_tab(f: &mut Frame, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .constraints([Constraint::Min(10), Constraint::Length(10)].as_ref())
+        .direction(Direction::Vertical)
+        .split(area);
+
+    let normal_style = Style::default().fg(Color::Green);
+    let selected_style = Style::default()
+        .fg(Color::Black)
+        .bg(Color::LightMagenta)
+        .add_modifier(Modifier::BOLD);
+
+    let rows = app.process_list.iter().map(|p| {
+        let ports_str: String = {
+            let mut sorted: Vec<u16> = p.ports.iter().copied().collect();
+            sorted.sort();
+            sorted
+                .iter()
+                .take(5)
+                .map(|port| format_port(*port))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        Row::new(vec![
+            p.name.clone(),
+            p.ips.len().to_string(),
+            p.total_connections.to_string(),
+            ports_str,
+        ])
+        .style(normal_style)
+    });
+
+    let widths = [
+        Constraint::Length(25),
+        Constraint::Length(10),
+        Constraint::Length(14),
+        Constraint::Min(20),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(
+            Row::new(vec!["Process", "Unique IPs", "Connections", "Ports"])
+                .style(
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .bottom_margin(1),
+        )
+        .block(
+            Block::default()
+                .title("Processes (↑↓ to select)")
+                .borders(Borders::ALL),
+        )
+        .row_highlight_style(selected_style)
+        .highlight_symbol("► ");
+
+    f.render_stateful_widget(table, chunks[0], &mut app.process_table_state);
+
+    // Process detail pane
+    let detail_text = if let Some(selected) = app.process_table_state.selected() {
+        if let Some(proc) = app.process_list.get(selected) {
+            let ips_str = if proc.ips.len() <= 5 {
+                proc.ips.join(", ")
+            } else {
+                format!(
+                    "{} ... and {} more",
+                    proc.ips[..5].join(", "),
+                    proc.ips.len() - 5
+                )
+            };
+            vec![
+                Line::from(vec![
+                    Span::styled("  Process: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        &proc.name,
+                        Style::default()
+                            .fg(Color::LightMagenta)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  Unique IPs: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        proc.ips.len().to_string(),
+                        Style::default().fg(Color::White),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled(
+                        "  Total connections: ",
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::styled(
+                        proc.total_connections.to_string(),
+                        Style::default().fg(Color::LightGreen),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  Connected to: ", Style::default().fg(Color::DarkGray)),
+                    Span::styled(ips_str, Style::default().fg(Color::LightCyan)),
+                ]),
+            ]
+        } else {
+            vec![Line::from("")]
+        }
+    } else {
+        vec![Line::from(Span::styled(
+            "  No process selected",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    };
+
+    let detail = Paragraph::new(detail_text)
+        .block(
+            Block::default()
+                .title("Process Details")
+                .borders(Borders::ALL),
+        )
+        .style(Style::default().fg(Color::White));
+
+    f.render_widget(detail, chunks[1]);
+}
+
+fn draw_help_tab(f: &mut Frame, _app: &mut App, area: Rect) {
+    let text = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ← → ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Switch tabs", Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ↑ ↓ ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Navigate server/process list", Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Enter ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Open detailed stats for selected server", Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Esc ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Close popup / Quit", Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  q ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Quit", Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("  h ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("Show this help", Style::default().fg(Color::White)),
+        ]),
+    ];
+
+    let p = Paragraph::new(text)
+        .block(Block::default().title("Help").borders(Borders::ALL))
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(p, area);
+}
+
+fn draw_detail_popup(f: &mut Frame, app: &mut App) {
+    let area = centered_rect(65, 75, f.area());
+
+    // Clear background
+    f.render_widget(Clear, area);
+
+    // Get server and history data
+    let server = match app.selected_server() {
+        Some(s) => s,
+        None => {
+            app.show_detail_popup = false;
+            return;
+        }
+    };
+    let ip = server.name.clone();
+    let location = format!("{}, {}", server.location, server.country);
+    let current_count = server.count;
+    let current_ports = server
+        .ports
+        .iter()
+        .map(|p| format_port(*p))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let current_procs = server.processes.join(", ");
+
+    let history = app.server_history.get(&ip);
+
+    // Build text content
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  IP: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                &ip,
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Location: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&location, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Current connections: ",
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                current_count.to_string(),
+                Style::default().fg(Color::LightGreen),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    if let Some(hist) = history {
+        let duration = hist.last_seen.duration_since(hist.first_seen);
+        let duration_str = format_duration(duration);
+        let avg = if hist.times_detected > 0 {
+            hist.total_connections as f64 / hist.times_detected as f64
+        } else {
+            0.0
+        };
+
+        // Frequency bar
+        let recent: Vec<u64> = hist.recent_counts.iter().copied().collect();
+        let active_ticks = recent.iter().filter(|&&c| c > 0).count();
+        let freq_pct = if !recent.is_empty() {
+            (active_ticks as f64 / recent.len() as f64 * 100.0) as u32
+        } else {
+            0
+        };
+        let filled = (freq_pct as usize) / 5;
+        let empty = 20 - filled.min(20);
+        let freq_bar = format!(
+            "{}{} {}%",
+            "█".repeat(filled.min(20)),
+            "░".repeat(empty),
+            freq_pct
+        );
+
+        lines.extend(vec![
+            Line::from(Span::styled(
+                "  ── Session Stats ──────────────────────────",
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(vec![
+                Span::styled(
+                    "  Tracking for: ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(duration_str, Style::default().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "  Times detected: ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    format!("{} polling cycles", hist.times_detected),
+                    Style::default().fg(Color::LightGreen),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "  Total connections: ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    hist.total_connections.to_string(),
+                    Style::default().fg(Color::LightGreen),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "  Avg per detection: ",
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(format!("{:.1}", avg), Style::default().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Frequency: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(freq_bar, Style::default().fg(Color::LightCyan)),
+            ]),
+            Line::from(""),
+        ]);
+
+        // All-time ports
+        let mut all_ports: Vec<u16> = hist.all_ports.iter().copied().collect();
+        all_ports.sort();
+        let all_ports_str = all_ports
+            .iter()
+            .map(|p| format_port(*p))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let mut all_procs: Vec<&String> = hist.all_processes.iter().collect();
+        all_procs.sort();
+        let all_procs_str = all_procs
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        lines.extend(vec![
+            Line::from(Span::styled(
+                "  ── All-Time (this session) ────────────────",
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(vec![
+                Span::styled("  Ports seen: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(all_ports_str, Style::default().fg(Color::LightCyan)),
+            ]),
+            Line::from(vec![
+                Span::styled("  Processes: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(all_procs_str, Style::default().fg(Color::LightMagenta)),
+            ]),
+        ]);
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  Current ports: ",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(&current_ports, Style::default().fg(Color::LightCyan)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  Current processes: ",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(&current_procs, Style::default().fg(Color::LightMagenta)),
+    ]));
+
+    // Split popup area: text + sparkline
+    let popup_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(5)])
+        .split(area);
+
+    let popup = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(" Server Detail ── Esc to close ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::LightCyan)),
+        )
+        .style(Style::default().fg(Color::White))
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(popup, popup_chunks[0]);
+
+    // Sparkline showing recent connection counts
+    if let Some(hist) = app.server_history.get(&ip) {
+        let data: Vec<u64> = hist.recent_counts.iter().copied().collect();
+        let sparkline = Sparkline::default()
+            .block(
+                Block::default()
+                    .title(" Connections (last 60 ticks) ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::LightCyan)),
+            )
+            .data(&data)
+            .style(Style::default().fg(Color::LightGreen));
+
+        f.render_widget(sparkline, popup_chunks[1]);
+    }
+}
+
+/// Helper to create a centered rect
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
+}
+
+/// Format a duration into a human-readable string
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+/// Map well-known ports to service names
+fn format_port(port: u16) -> String {
+    let service = match port {
+        22 => "SSH",
+        53 => "DNS",
+        80 => "HTTP",
+        443 => "HTTPS",
+        993 => "IMAPS",
+        995 => "POP3S",
+        3306 => "MySQL",
+        5432 => "PostgreSQL",
+        6379 => "Redis",
+        8080 => "HTTP-Alt",
+        8443 => "HTTPS-Alt",
+        _ => "",
+    };
+    if service.is_empty() {
+        format!("{}", port)
+    } else {
+        format!("{} ({})", port, service)
+    }
 }


### PR DESCRIPTION
## Summary
- **Auto-download GeoIP database** on first run — no more manual `wget`! Uses DB-IP City Lite (CC-BY-4.0). Stored in platform data dir (`~/.local/share/maperick/` or equivalent)
- **Interactive server table** — ↑↓ to select, Enter to open a detailed stats popup with session history, frequency bar, and sparkline chart
- **New Processes tab** — see connections grouped by process name (e.g., chrome, ssh, curl) with unique IP count and total connections
- **UI fixes** — visible tab bar, proper tab names, color-coded markers, removed broken connection lines, better help page
- **Code cleanup** — removed 7 unused deps, added crates.io metadata, new `geodb` module

## New Features

### Auto-download GeoIP DB
```bash
# Just works now — no setup needed!
maperick -e

# Check where DB is stored
maperick --db-path

# Or install globally
just install
```

### Stats Popup (Enter on Servers tab)
Shows per-IP session stats:
- First/last seen, tracking duration
- Times detected (polling cycles)
- Total connections & average per detection
- Frequency bar (what % of recent ticks had this IP)
- Sparkline of connection counts over last 60 ticks
- All ports and processes ever seen

### Processes Tab
- Connections grouped by process name
- Shows unique IPs, total connections, ports per process
- ↑↓ selection with detail pane

## Test plan
- [x] `cargo test` — 15 tests pass
- [x] `cargo build` — clean compile (1 dead_code warning for future use)
- [ ] Run `cargo run -- -e` and verify Map, Servers, Processes, Help tabs
- [ ] On Servers tab: arrow keys navigate, Enter opens popup, Esc closes
- [ ] First run without existing DB: auto-downloads successfully
- [ ] `maperick --db-path` prints correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)